### PR TITLE
Fix to unignore bin/data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,6 @@ xcuserdata/
 
 .svn/
 obj/
-bin/
+bin/*
 build/
-!data/
+!bin/data/


### PR DESCRIPTION
The combination the following two lines in `.gitignore`

```
bin/
!data/
```

were not allowing files in `bin/data` into the repository.
